### PR TITLE
Add the missing tagger mode

### DIFF
--- a/modes.xml
+++ b/modes.xml
@@ -16,7 +16,21 @@
       </program>
     </pipeline>
   </mode>
-
+  
+  <mode name="ara-tagger" install="yes">
+    <pipeline>
+      <program name="lt-proc -w">
+        <file name="ara.automorf.bin"/>
+      </program>
+      <program name="cg-proc -w">
+        <file name="ara.rlx.bin"/>
+      </program>
+      <program name="apertium-tagger -g">
+        <file name="ara.prob"/>
+      </program>     
+    </pipeline>
+  </mode>
+  
   <mode name="ara-disam" install="yes">
     <pipeline>
       <program name="lt-proc -w">


### PR DESCRIPTION
The `modes.xml` file doesn't include a tagger mode although all the required files are available.